### PR TITLE
index.js: handle new release asset filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,13 +74,13 @@ async function getReleases() {
 
   for (const release of jsonResponse) {
     for (const asset of release['assets']) {
-      if (asset['name'] == 'willow-dist-ESP32_S3_BOX.bin') {
+      if (asset['name'] == 'willow-dist-ESP32_S3_BOX.bin' || asset['name'] == 'willow-dist-ESP32-S3-BOX.bin') {
         console.log("Adding", release['tag_name'], asset['browser_download_url']);
         willowReleases['ESP32_S3_BOX'].push({'version': release['tag_name'], 'url': asset['browser_download_url'], 'prerelease': release['prerelease']});
-      } else if (asset['name'] == 'willow-dist-ESP32_S3_BOX_3.bin') {
+      } else if (asset['name'] == 'willow-dist-ESP32_S3_BOX_3.bin' || asset['name'] == 'willow-dist-ESP32-S3-BOX-3.bin') {
         console.log("Adding", release['tag_name'], asset['browser_download_url']);
         willowReleases['ESP32_S3_BOX_3'].push({'version': release['tag_name'], 'url': asset['browser_download_url'], 'prerelease': release['prerelease']});
-      } else if (asset['name'] == 'willow-dist-ESP32_S3_BOX_LITE.bin') {
+      } else if (asset['name'] == 'willow-dist-ESP32_S3_BOX_LITE.bin' || asset['name'] == 'willow-dist-ESP32-S3-BOX-LITE.bin') {
         console.log("Adding", release['tag_name'], asset['browser_download_url']);
         willowReleases['ESP32_S3_BOX_LITE'].push({'version': release['tag_name'], 'url': asset['browser_download_url'], 'prerelease': release['prerelease']});
       }


### PR DESCRIPTION
Commit toverainc/willow@06e27f4896ebf14fcf4465abcbe3750150fc8ce5 changed the release asset filenames. After deleting the temporary Willow release for the ESP32-S3-Box-3, this result in no releases being added to the internal release dict.

Fixes: #12